### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project assumes you have a single monolithic repository containing
 multiple packages as well as third-party dependencies using Composer.
 
 You would create a `composer.json` file in the root of your project and use
-this single source of vendor libraries accross all of your own packages.
+this single source of vendor libraries across all of your own packages.
 
 This sounds counter-intuitive to the Composer approach at first, but
 it simplifies dependency management for a big project massively. Usually


### PR DESCRIPTION
@beberlei, I've corrected a typographical error in the documentation of the [fiddler](https://github.com/beberlei/fiddler) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.